### PR TITLE
Support stdout

### DIFF
--- a/pangeo_forge_runner/__main__.py
+++ b/pangeo_forge_runner/__main__.py
@@ -65,9 +65,7 @@ def main():
     argparser.add_argument(
         "--ref", default=None, help="Ref to check out of the repo to build"
     )
-    argparser.add_argument(
-        "--quiet", default=False, help="If true, suppress logs."
-    )
+    argparser.add_argument("--logs", action=argparse.BooleanOptionalAction)
 
     commands = argparser.add_subparsers(dest="command")
 
@@ -81,7 +79,8 @@ def main():
 
     if args.command == "expand-meta":
         with tempfile.TemporaryDirectory() as checkout_dir:
-            fetch(args.repo, args.ref, checkout_dir)
+            quiet = False if args.logs else True
+            fetch(args.repo, args.ref, checkout_dir, quiet)
             feedstock = Feedstock(Path(checkout_dir))
             expanded = feedstock.get_expanded_meta()
             if args.out:

--- a/tests/test_expand_meta.py
+++ b/tests/test_expand_meta.py
@@ -5,15 +5,10 @@ import subprocess
 
 invocations = [
     {
-        "repo": "https://github.com/pangeo-forge/cmip6-feedstock",
-        "ref": "63f544892df0f6c7c61bf372bfd52366cd885aa7",
-        "meta": {"title": "CMIP6", "description": "CMIP6 datasets converted to zarr stores from ESGF files", "pangeo_forge_version": "0.8.3", "pangeo_notebook_version": "2021.12.02", "recipes": [{"id": "CMIP6.PMIP.MIROC.MIROC-ES2L.past1000.r1i1p1f2.Amon.tas.gn.v20200318"}, {"id": "CMIP6.PMIP.MRI.MRI-ESM2-0.past1000.r1i1p1f1.Amon.tas.gn.v20200120"}, {"id": "CMIP6.PMIP.MPI-M.MPI-ESM1-2-LR.past2k.r1i1p1f1.Amon.tas.gn.v20210714"}], "provenance": {"providers": [{"name": "ESGF", "description": "Earth System Grid Federation", "roles": ["producer", "licensor"], "url": "https://esgf-node.llnl.gov/projects/cmip6/"}], "license": "CC-BY-4.0"}, "maintainers": [{"name": "Julius Busecke", "orcid": "0000-0001-8571-865X", "github": "jbusecke"}, {"name": "Charles Stern", "orcid": "0000-0002-4078-0852", "github": "cisaacstern"}], "bakery": {"id": "pangeo-ldeo-nsf-earthcube"}}
-    },
-    {
         "repo": "https://github.com/pangeo-forge/gpcp-feedstock",
         "ref": "2cde04745189665a1f5a05c9eae2a98578de8b7f",
         "meta": {"title": "Global Precipitation Climatology Project", "description": "Global Precipitation Climatology Project (GPCP) Daily Version 1.3 gridded, merged ty satellite/gauge precipitation Climate data Record (CDR) from 1996 to present.\n", "pangeo_forge_version": "0.9.0", "pangeo_notebook_version": "2022.06.02", "recipes": [{"id": "gpcp", "object": "recipe:recipe"}], "provenance": {"providers": [{"name": "NOAA NCEI", "description": "National Oceanographic & Atmospheric Administration National Centers for Environmental Information", "roles": ["host", "licensor"], "url": "https://www.ncei.noaa.gov/products/global-precipitation-climatology-project"}, {"name": "University of Maryland", "description": "University of Maryland College Park Earth System Science Interdisciplinary Center (ESSIC) and Cooperative Institute for Climate and Satellites (CICS).\n", "roles": ["producer"], "url": "http://gpcp.umd.edu/"}], "license": "No constraints on data access or use."}, "maintainers": [{"name": "Ryan Abernathey", "orcid": "0000-0001-5999-4917", "github": "rabernat"}], "bakery": {"id": "pangeo-ldeo-nsf-earthcube"}}
-    }
+    },
 ]
 
 


### PR DESCRIPTION
@yuvipanda, this PR adds support for stdout, so a controller process can get the results of e.g. `expand-meta` via `subprocess.check_output` and therefore doesn't need to interact with a shared filesystem. Not attached to this specific implementation if you see a better way this could be done! 🙏 