### PR TITLE
Add job_name override option to bake command

### DIFF
--- a/pangeo_forge_runner/commands/bake.py
+++ b/pangeo_forge_runner/commands/bake.py
@@ -66,6 +66,17 @@ class Bake(BaseCommand):
         """,
     )
 
+    job_name = Unicode(
+        None,
+        allow_none=True,
+        config=True,
+        help="""
+        Optionally pass a custom job name for the job run.
+
+        If empty, a name will be generated for the job below.
+        """,
+    )
+
     def start(self):
         """
         Start the baking process
@@ -112,19 +123,20 @@ class Bake(BaseCommand):
 
             for name, recipe in recipes.items():
                 # Unique name for running this particular recipe.
-                # FIXME: Should include the name of repo / ref as well somehow
-                job_name = (
-                    f"{name}-{recipe.sha256().hex()}-{int(datetime.now().timestamp())}"
-                )
+                if not self.job_name:
+                    # FIXME: Should include the name of repo / ref as well somehow
+                    self.job_name = (
+                        f"{name}-{recipe.sha256().hex()}-{int(datetime.now().timestamp())}"
+                    )
 
                 recipe.storage_config = StorageConfig(
-                    target_storage.get_forge_target(job_name=job_name),
-                    input_cache_storage.get_forge_target(job_name=job_name),
-                    metadata_cache_storage.get_forge_target(job_name=job_name),
+                    target_storage.get_forge_target(job_name=self.job_name),
+                    input_cache_storage.get_forge_target(job_name=self.job_name),
+                    metadata_cache_storage.get_forge_target(job_name=self.job_name),
                 )
 
                 pipeline_options = bakery.get_pipeline_options(
-                    job_name=job_name,
+                    job_name=self.job_name,
                     # FIXME: Bring this in from meta.yaml?
                     container_image="pangeo/forge:8a862dc",
                 )

--- a/pangeo_forge_runner/commands/bake.py
+++ b/pangeo_forge_runner/commands/bake.py
@@ -130,7 +130,7 @@ class Bake(BaseCommand):
                     job_name = self.job_name
 
                 recipe.storage_config = StorageConfig(
-                    target_storage.get_forge_target(job_name=self.job_name),
+                    target_storage.get_forge_target(job_name=job_name),
                     input_cache_storage.get_forge_target(job_name=self.job_name),
                     metadata_cache_storage.get_forge_target(job_name=self.job_name),
                 )

--- a/pangeo_forge_runner/commands/bake.py
+++ b/pangeo_forge_runner/commands/bake.py
@@ -125,9 +125,7 @@ class Bake(BaseCommand):
                 # Unique name for running this particular recipe.
                 if not self.job_name:
                     # FIXME: Should include the name of repo / ref as well somehow
-                    self.job_name = (
-                        f"{name}-{recipe.sha256().hex()}-{int(datetime.now().timestamp())}"
-                    )
+                    self.job_name = f"{name}-{recipe.sha256().hex()}-{int(datetime.now().timestamp())}"
 
                 recipe.storage_config = StorageConfig(
                     target_storage.get_forge_target(job_name=self.job_name),

--- a/pangeo_forge_runner/commands/bake.py
+++ b/pangeo_forge_runner/commands/bake.py
@@ -73,7 +73,7 @@ class Bake(BaseCommand):
         help="""
         Optionally pass a custom job name for the job run.
 
-        If empty, a unique name will be generated for the job.
+        If `None` (the default), a unique name will be generated for the job.
         """,
     )
 

--- a/pangeo_forge_runner/commands/bake.py
+++ b/pangeo_forge_runner/commands/bake.py
@@ -131,7 +131,7 @@ class Bake(BaseCommand):
 
                 recipe.storage_config = StorageConfig(
                     target_storage.get_forge_target(job_name=job_name),
-                    input_cache_storage.get_forge_target(job_name=self.job_name),
+                    input_cache_storage.get_forge_target(job_name=job_name),
                     metadata_cache_storage.get_forge_target(job_name=self.job_name),
                 )
 

--- a/pangeo_forge_runner/commands/bake.py
+++ b/pangeo_forge_runner/commands/bake.py
@@ -73,7 +73,7 @@ class Bake(BaseCommand):
         help="""
         Optionally pass a custom job name for the job run.
 
-        If empty, a name will be generated for the job below.
+        If empty, a unique name will be generated for the job.
         """,
     )
 

--- a/pangeo_forge_runner/commands/bake.py
+++ b/pangeo_forge_runner/commands/bake.py
@@ -132,7 +132,7 @@ class Bake(BaseCommand):
                 recipe.storage_config = StorageConfig(
                     target_storage.get_forge_target(job_name=job_name),
                     input_cache_storage.get_forge_target(job_name=job_name),
-                    metadata_cache_storage.get_forge_target(job_name=self.job_name),
+                    metadata_cache_storage.get_forge_target(job_name=job_name),
                 )
 
                 pipeline_options = bakery.get_pipeline_options(

--- a/pangeo_forge_runner/commands/bake.py
+++ b/pangeo_forge_runner/commands/bake.py
@@ -138,7 +138,7 @@ class Bake(BaseCommand):
                 )
 
                 pipeline_options = bakery.get_pipeline_options(
-                    job_name=self.job_name,
+                    job_name=job_name,
                     # FIXME: Bring this in from meta.yaml?
                     container_image="pangeo/forge:8a862dc",
                 )

--- a/pangeo_forge_runner/commands/bake.py
+++ b/pangeo_forge_runner/commands/bake.py
@@ -152,10 +152,11 @@ class Bake(BaseCommand):
                 # Some bakeries are blocking - if Beam is configured to use them, calling
                 # pipeline.run() blocks. Some are not. We handle that here, and provide
                 # appropriate feedback to the user too.
+                extra = {"recipe": name, "job_name": job_name}
                 if bakery.blocking:
                     self.log.info(
                         f"Running job for recipe {name}\n",
-                        extra={"recipe": "name", "status": "running"},
+                        extra=extra | {"status": "running"},
                     )
                     pipeline.run()
                 else:
@@ -163,5 +164,5 @@ class Bake(BaseCommand):
                     job_id = result.job_id()
                     self.log.info(
                         f"Submitted job {job_id} for recipe {name}",
-                        extra={"job_id": job_id, "recipe": name, "status": "submitted"},
+                        extra=extra | {"job_id": job_id, "status": "submitted"},
                     )

--- a/pangeo_forge_runner/commands/bake.py
+++ b/pangeo_forge_runner/commands/bake.py
@@ -125,7 +125,9 @@ class Bake(BaseCommand):
                 # Unique name for running this particular recipe.
                 if not self.job_name:
                     # FIXME: Should include the name of repo / ref as well somehow
-                    self.job_name = f"{name}-{recipe.sha256().hex()}-{int(datetime.now().timestamp())}"
+                    job_name = f"{name}-{recipe.sha256().hex()}-{int(datetime.now().timestamp())}"
+                else:
+                    job_name = self.job_name
 
                 recipe.storage_config = StorageConfig(
                     target_storage.get_forge_target(job_name=self.job_name),


### PR DESCRIPTION
This supersedes #17 as a way to pass backend app context information into Dataflow: via the job_name.

This should go in after #14 & #15 (or instead of them), as it incorporates changes from those PRs.

I will circle back to add tests shortly. 🙏 